### PR TITLE
Only compile tests.go when testing

### DIFF
--- a/drivers/store/common/tests.go
+++ b/drivers/store/common/tests.go
@@ -1,3 +1,5 @@
+//+build test
+
 package common
 
 import (


### PR DESCRIPTION
This prevents having to pull in the dependency "github.com/stretchr/testify/require" on normal use.